### PR TITLE
Browser streams support & concurrency 

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,5 +11,6 @@
     "source.fixAll.eslint": "explicit"
   },
   "typescript.tsdk": "node_modules/typescript/lib",
-  "vitest.disableWorkspaceWarning": true
+  "vitest.disableWorkspaceWarning": true,
+  "java.configuration.updateBuildConfiguration": "interactive"
 }

--- a/lib/lib-storage/src/s3-transfer-manager/S3TransferManager.e2e.spec.ts
+++ b/lib/lib-storage/src/s3-transfer-manager/S3TransferManager.e2e.spec.ts
@@ -31,15 +31,16 @@ describe(S3TransferManager.name, () => {
   let region: string;
 
   beforeAll(async () => {
-    // const integTestResourcesEnv = await getIntegTestResources();
-    // Object.assign(process.env, integTestResourcesEnv);
+    // TODO: replace hard coded region and bucket with integration test resources.
+    const integTestResourcesEnv = await getIntegTestResources();
+    Object.assign(process.env, integTestResourcesEnv);
 
-    // region = process?.env?.AWS_SMOKE_TEST_REGION as string;
-    // Bucket = process?.env?.AWS_SMOKE_TEST_BUCKET as string;
+    region = process?.env?.AWS_SMOKE_TEST_REGION as string;
+    Bucket = process?.env?.AWS_SMOKE_TEST_BUCKET as string;
     void getIntegTestResources;
 
-    region = "us-west-2";
-    Bucket = "lukachad-us-west-2";
+    // region = "us-west-2";
+    // Bucket = "lukachad-us-west-2";
 
     client = new S3({
       region,
@@ -54,7 +55,7 @@ describe(S3TransferManager.name, () => {
     });
   }, 120_000);
 
-  describe.skip("multi part download", () => {
+  describe("multi part download", () => {
     const modes = ["PART", "RANGE"] as S3TransferManagerConfig["multipartDownloadType"][];
     const sizes = [6, 11] as number[];
 
@@ -92,13 +93,12 @@ describe(S3TransferManager.name, () => {
             },
             {
               eventListeners: {
-                transferInitiated: [({ request, snapshot }) => {}],
                 bytesTransferred: [
                   ({ request, snapshot }) => {
                     bytesTransferred = snapshot.transferredBytes;
+                    // console.log(bytesTransferred);
                   },
                 ],
-                transferComplete: [({ request, snapshot, response }) => {}],
               },
             }
           );
@@ -111,7 +111,7 @@ describe(S3TransferManager.name, () => {
     }
   });
 
-  describe("(SEP) download single object tests", () => {
+  describe.skip("(SEP) download single object tests", () => {
     async function sepTests(
       objectType: "single" | "multipart",
       multipartType: "PART" | "RANGE",
@@ -151,7 +151,7 @@ describe(S3TransferManager.name, () => {
       const serialized = await download.Body?.transformToString();
       check(serialized);
       if (partNumber) {
-        expect(serialized?.length).toEqual(DEFAULT_PART_SIZE);
+        expect(serialized?.length).toEqual(4 * 1024 * 1024); // Part 1 is 8MB Part 2 is 4MB
       } else {
         expect(serialized?.length).toEqual(Body.length);
       }
@@ -163,10 +163,11 @@ describe(S3TransferManager.name, () => {
     it("multipart object: multipartDownloadType = RANGE, range = 0-12MB, partNumber = null", async () => {
       await sepTests("multipart", "RANGE", `bytes=0-${12 * 1024 * 1024}`, undefined);
     }, 60_000);
-    it("single object: multipartDownloadType = PART, range = null, partNumber = 2", async () => {
+    // skipped because TM no longer supports partNumber
+    it.skip("single object: multipartDownloadType = PART, range = null, partNumber = 2", async () => {
       await sepTests("single", "PART", undefined, 2);
     }, 60_000);
-    it("single object: multipartDownloadType = RANGE, range = null, partNumber = 2", async () => {
+    it.skip("single object: multipartDownloadType = RANGE, range = null, partNumber = 2", async () => {
       await sepTests("single", "RANGE", undefined, 2);
     }, 60_000);
     it("single object: multipartDownloadType = PART, range = null, partNumber = null", async () => {

--- a/lib/lib-storage/src/s3-transfer-manager/S3TransferManager.e2e.spec.ts
+++ b/lib/lib-storage/src/s3-transfer-manager/S3TransferManager.e2e.spec.ts
@@ -31,16 +31,12 @@ describe(S3TransferManager.name, () => {
   let region: string;
 
   beforeAll(async () => {
-    // TODO: replace hard coded region and bucket with integration test resources.
     const integTestResourcesEnv = await getIntegTestResources();
     Object.assign(process.env, integTestResourcesEnv);
 
     region = process?.env?.AWS_SMOKE_TEST_REGION as string;
     Bucket = process?.env?.AWS_SMOKE_TEST_BUCKET as string;
     void getIntegTestResources;
-
-    // region = "us-west-2";
-    // Bucket = "lukachad-us-west-2";
 
     client = new S3({
       region,
@@ -96,7 +92,6 @@ describe(S3TransferManager.name, () => {
                 bytesTransferred: [
                   ({ request, snapshot }) => {
                     bytesTransferred = snapshot.transferredBytes;
-                    // console.log(bytesTransferred);
                   },
                 ],
               },

--- a/lib/lib-storage/src/s3-transfer-manager/S3TransferManager.e2e.spec.ts
+++ b/lib/lib-storage/src/s3-transfer-manager/S3TransferManager.e2e.spec.ts
@@ -111,7 +111,7 @@ describe(S3TransferManager.name, () => {
     }
   });
 
-  describe.skip("(SEP) download single object tests", () => {
+  describe("(SEP) download single object tests", () => {
     async function sepTests(
       objectType: "single" | "multipart",
       multipartType: "PART" | "RANGE",

--- a/lib/lib-storage/src/s3-transfer-manager/join-streams.ts
+++ b/lib/lib-storage/src/s3-transfer-manager/join-streams.ts
@@ -1,17 +1,15 @@
 import { StreamingBlobPayloadOutputTypes } from "@smithy/types";
-import { isBlob, isReadableStream, sdkStreamMixin } from "@smithy/util-stream";
+import { isReadableStream, sdkStreamMixin } from "@smithy/util-stream";
 import { Readable } from "stream";
 
 import { JoinStreamIterationEvents } from "./types";
 
 // TODO: check all types. needs to join nodejs and browser together
-export function joinStreams(
-  streams: StreamingBlobPayloadOutputTypes[],
+export async function joinStreams(
+  streams: Promise<StreamingBlobPayloadOutputTypes>[],
   eventListeners?: JoinStreamIterationEvents
-): StreamingBlobPayloadOutputTypes {
-  if (streams.length === 1) {
-    return streams[0];
-  } else if (isReadableStream(streams[0])) {
+): Promise<StreamingBlobPayloadOutputTypes> {
+  if (isReadableStream(streams[0])) {
     const newReadableStream = new ReadableStream({
       async start(controller) {
         for await (const chunk of iterateStreams(streams, eventListeners)) {
@@ -21,43 +19,36 @@ export function joinStreams(
       },
     });
     return sdkStreamMixin(newReadableStream);
-  } else if (isBlob(streams[0])) {
-    throw new Error("Blob not supported yet");
   } else {
     return sdkStreamMixin(Readable.from(iterateStreams(streams, eventListeners)));
   }
 }
 
 export async function* iterateStreams(
-  streams: StreamingBlobPayloadOutputTypes[],
+  streams: Promise<StreamingBlobPayloadOutputTypes>[],
   eventListeners?: JoinStreamIterationEvents
 ): AsyncIterable<StreamingBlobPayloadOutputTypes, void, void> {
   let bytesTransferred = 0;
   let index = 0;
-  for (const stream of streams) {
+  for (const streamPromise of streams) {
+    const stream = await streamPromise;
     if (isReadableStream(stream)) {
-      // const reader = stream.getReader();
-      // while (true) {
-      //   const { done, value } = await reader.read();
-      //   if (done) {
-      //     break;
-      //   }
-      //   yield value;
-      //   bytesTransferred += value.byteLength;
-      // }
-      // reader.releaseLock();
-
-      const failure = new Error(`ReadableStreams not supported yet ${(stream as any)?.constructor?.name}`);
-      eventListeners?.onFailure?.(failure, index);
-      throw failure;
-    } else if (isBlob(stream)) {
-      throw new Error("Blob not supported yet");
+      const reader = stream.getReader();
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) {
+          break;
+        }
+        yield value;
+        bytesTransferred += value.byteLength;
+        eventListeners?.onBytes?.(bytesTransferred, index);
+      }
+      reader.releaseLock();
     } else if (stream instanceof Readable) {
       for await (const chunk of stream) {
         yield chunk;
         const chunkSize = Buffer.isBuffer(chunk) ? chunk.length : Buffer.byteLength(chunk);
         bytesTransferred += chunkSize;
-
         eventListeners?.onBytes?.(bytesTransferred, index);
       }
     } else {

--- a/lib/lib-storage/src/s3-transfer-manager/types.ts
+++ b/lib/lib-storage/src/s3-transfer-manager/types.ts
@@ -216,14 +216,14 @@ export interface IS3TransferManager {
     callback: EventListener<TransferEvent>,
     options?: AddEventListenerOptions | boolean
   ): void;
-  addEventListener(type: string, callback: EventListener | null, options?: AddEventListenerOptions | boolean): void;
+  addEventListener(type: string, callback: EventListener, options?: AddEventListenerOptions | boolean): void;
 
   /**
    * Dispatches an event to the registered event listeners.
    * Triggers callbacks registered via addEventListener with matching event types.
    *
    * @param event - The event object to dispatch.
-   * @returns whether the event dispatched successfully
+   * @returns whether the event ran to completion
    *
    * @public
    */
@@ -261,11 +261,7 @@ export interface IS3TransferManager {
     callback: EventListener<TransferEvent>,
     options?: RemoveEventListenerOptions | boolean
   ): void;
-  removeEventListener(
-    type: string,
-    callback: EventListener | null,
-    options?: RemoveEventListenerOptions | boolean
-  ): void;
+  removeEventListener(type: string, callback: EventListener, options?: RemoveEventListenerOptions | boolean): void;
 }
 
 /**


### PR DESCRIPTION
### Description
Changes made:
- modified S3TransferManager to make requests concurrently to improve download speed. Now matches GetObjectCommand and even improves on it's speed
- Compartmentalized RANGE and PART downloads into separate methods for readability. 
- Used getReader to lock the streams during multipart downloads to prevent premature termination.

### Testing
Local end to end testing, spec.ts and e2e.spec.ts files.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
